### PR TITLE
Concatenates output with resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Matt Smith <mtscout6@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "url": "^0.10.3",
     "webpack": "^1.5.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import url from 'url';
 import RequestShortener from 'webpack/lib/RequestShortener';
 
 function ExtractAssets(modules, requestShortener, publicPath) {
@@ -22,7 +23,7 @@ function ExtractAssets(modules, requestShortener, publicPath) {
     }).filter(m => {
       return m !== undefined;
     }).reduce((acc, m) => {
-      acc[m.name] = path.join(publicPath, m.asset);
+        acc[m.name] = url.resolve(publicPath, m.asset);
       return acc;
     }, {});
 
@@ -37,7 +38,7 @@ function ExtractChunks(chunks, publicPath) {
         name: c.name,
         files: c.files
           .filter(f => path.extname(f) !== '.map')
-          .map(f => path.join(publicPath, f))
+          .map(f => url.resolve(publicPath, f))
       };
     })
     .reduce((acc, c) => {

--- a/test/publicPath.js
+++ b/test/publicPath.js
@@ -1,0 +1,58 @@
+import _ from 'lodash';
+import path from 'path';
+import webpack from 'webpack';
+import rimraf from 'rimraf';
+import fs from 'fs';
+import config from './webpack.config';
+import touch from 'touch';
+import AssetMapPlugin from '../src';
+import asyncTestWrapper from './async-test-wrapper';
+
+config = _.cloneDeep(config);
+
+var baseDir = path.join(__dirname, 'app');
+
+config.plugins = [
+  new AssetMapPlugin(baseDir + '/assets/map.json')
+];
+
+var mapFilePath = config.plugins[0].outputFile;
+
+describe('Should work with relative and absolute publicPath', () => {
+  it('Generates map.json with relative urls if publicPath is relative', done => {
+    rimraf(config.output.path, () => {
+      webpack(config, (err, stats) => {
+        asyncTestWrapper(() => {
+          if (err) throw err;
+          if (stats.hasErrors()) throw 'webpack has errors';
+          if (stats.hasWarnings()) throw 'webpack has warnings';
+
+          var mapSrc = fs.readFileSync(mapFilePath, {encoding: 'utf-8'});
+          var map = JSON.parse(mapSrc).assets;
+
+          map['../smiley.jpeg'].should.match(/^\/assets\/smiley-[0-9a-f]+\.jpeg$/);
+          map['../test-checklist.jpeg'].should.match(/^\/assets\/test-checklist-[0-9a-f]+\.jpeg$/);
+        }, done);
+      });
+    });
+  });
+
+  it('Generates map.json with absolute urls if publicPath is absolute', done => {
+      rimraf(config.output.path, () => {
+      config.output.publicPath = 'https://mycdn.mysite.com/';
+      webpack(config, (err, stats) => {
+        asyncTestWrapper(() => {
+          if (err) throw err;
+          if (stats.hasErrors()) throw 'webpack has errors';
+          if (stats.hasWarnings()) throw 'webpack has warnings';
+
+          var mapSrc = fs.readFileSync(mapFilePath, {encoding: 'utf-8'});
+          var map = JSON.parse(mapSrc).assets;
+
+          map['../smiley.jpeg'].should.match(/^https:\/\/mycdn.mysite.com\/smiley-[0-9a-f]+\.jpeg$/);
+          map['../test-checklist.jpeg'].should.match(/^https:\/\/mycdn.mysite.com\/test-checklist-[0-9a-f]+\.jpeg$/);
+        }, done);
+      });
+    });
+  });
+});


### PR DESCRIPTION
In webpack, publicPath can be an url (eg: when you serve your assets
from a CDN.
Using path.join() caused issues, by generating incorrect urls.
Eg:
    path.join('https://my.cdn.com/assets/', 'logo.jpg')
        >> 'https:/my.cdn.com/assets/logo.jpg'  (one / is missing)
    url.resolve('https://my.cdn.com/assets/', 'logo.jpg')
        >> 'https://my.cdn.com/assets/logo.jpg'  (correct)
