### PR TITLE
Upgrades to support webpack 2/3

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["env"]
 }

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The key is the relative path from the generated file to the image location in yo
 
 ## Usage
 
+For webpack 1, use version 2.x of `asset-map-webpack-plugin`; for webpack 2/3, use version 3.x.
+
 Add to the plugins array in your webpack config:
 
 ``` javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asset-map-webpack-plugin",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Webpack plugin that creates a map of assets to public url slug for server agnostic usage.",
   "main": "lib/index.js",
   "scripts": {
@@ -12,22 +12,22 @@
   "license": "MIT",
   "dependencies": {
     "url": "^0.10.3",
-    "webpack": "^1.5.3"
+    "webpack": "^2 || ^3"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-cli": "^6.26.0",
+    "babel-preset-env": "^1.6.1",
     "chai": "^2.0.0",
-    "css-loader": "^0.9.1",
+    "css-loader": "^0.28.9",
     "eslint": "^4.2.0",
-    "extract-text-webpack-plugin": "^0.3.8",
-    "file-loader": "^0.8.1",
+    "extract-text-webpack-plugin": "^3.0.2",
+    "file-loader": "^1.1.6",
     "less": "^2.4.0",
-    "less-loader": "^2.0.0",
+    "less-loader": "^4.0.5",
     "lodash": "^3.3.1",
     "mocha": "^3.4.2",
     "rimraf": "^2.2.8",
-    "style-loader": "^0.8.3",
+    "style-loader": "^0.19.1",
     "touch": "^3.1.0"
   },
   "repository": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -94,6 +94,11 @@ describe('Basic use case', () => {
           touch.sync(smiley);
         },
         function Wait() {
+          // twice to ensure it's done before the next step
+          touch.sync(entry2Js);
+        },
+        function Wait() {
+          // twice to ensure it's done before the next step
           touch.sync(entry2Js);
         },
         function ExpectChangeAndRewriteAsset() {
@@ -139,5 +144,5 @@ describe('Basic use case', () => {
         }
       });
     });
-  }).timeout(10000);
+  }).timeout(15000);
 });

--- a/test/extract-text-plugin.js
+++ b/test/extract-text-plugin.js
@@ -14,12 +14,12 @@ const config = _.cloneDeep(defaultConfig);
 
 const baseDir = path.join(__dirname, 'app');
 
-config.module.loaders = config.module.loaders.map(l => {
-  if (l.loader.indexOf('less') === -1) {
+config.module.rules = config.module.rules.map(l => {
+  if (!Array.isArray(l.use) || !l.use.includes('less-loader')) {
     return l;
   }
 
-  l.loader = ExtractTextPlugin.extract('style', 'css!less');
+  l.use = ExtractTextPlugin.extract({ fallback: 'style-loader', use: ['css-loader', 'less-loader'] });
   return l;
 });
 

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -17,10 +17,10 @@ export default {
   },
 
   module: {
-    loaders: [
-      { test: /\.css$/, loader: 'style!css' },
-      { test: /\.less/, loader: 'style!css!less' },
-      { test: /\.jpeg/, loader: 'file?name=[name]-[hash].[ext]' }
+    rules: [
+      { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+      { test: /\.less/, use: ['style-loader', 'css-loader', 'less-loader'] },
+      { test: /\.jpeg/, use: 'file-loader?name=[name]-[hash].[ext]' }
     ]
   }
 };


### PR DESCRIPTION
No actual code changes are needed, but I'm not sure of a good way to keep webpack 1 and 2/3 under the same supported test suite, so I created a new major version for webpack 2/3. Any future bugfixes for webpack 1 can go in the webpack-1 branch and be released as a 2.x version.

* Expanded package.json version to allow webpack 2/3
* Upgraded loaders etc used in test suite, rewrite deprecated syntax
* Added note to README about which version to use